### PR TITLE
convert page_aligned_vec!() into Qcow2Iobuf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  build_linux:
     name: Rust project - latest
     runs-on: ubuntu-latest
     strategy:
@@ -23,3 +23,32 @@ jobs:
       - run: cargo build --verbose
       - run: cargo test -- --nocapture
       - run: cargo test -r
+
+  build_win:
+    name: Rust project - latest
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+    steps:
+     - name: Checkout repository
+       uses: actions/checkout@v4
+     - name: Install Chocolatey
+       run: |
+        $qemuZipPath = Join-Path $env:USERPROFILE 'qemu.zip'
+        Invoke-WebRequest -Uri 'https://cloudbase.it/downloads/qemu-img-win-x64-2_3_0.zip' -OutFile $qemuZipPath
+        Expand-Archive -Path $qemuZipPath -DestinationPath $env:USERPROFILE
+     - run: |
+        $env:PATH = "$env:USERPROFILE;$env:PATH"
+        qemu-img --help
+     - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+     - run: cargo build --verbose
+     - name: Rust test(debug)
+       run: |
+        $env:PATH = "$env:USERPROFILE;$env:PATH"
+        cargo test -- --nocapture
+     - name: Rust test(release)
+       run: |
+        $env:PATH = "$env:USERPROFILE;$env:PATH"
+        cargo test -r

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ host cluster leak, format qcow2 image, ....
             .await
             .unwrap();
 
-        let mut buf = qcow2_rs::page_aligned_vec!(u8, 4096);
+        let mut buf = qcow2_rs::helpers::Qcow2IoBuf::<u8>::new(4096);
 
         // read 4096 bytes to `buf` from virt offset 0 of `test.qcow2`
         let _ = dev.read_at(&mut buf, 0).await.unwrap();

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -114,6 +114,10 @@ pub struct Qcow2IoBuf<T> {
     size: usize,
 }
 
+// Users of Qcow2IoBuf has to deal with Send & Sync
+unsafe impl<T> Send for Qcow2IoBuf<T> {}
+unsafe impl<T> Sync for Qcow2IoBuf<T> {}
+
 impl<'a, T> Qcow2IoBuf<T> {
     pub fn new(size: usize) -> Self {
         let layout = std::alloc::Layout::from_size_align(size, 4096).unwrap();

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -89,24 +89,6 @@ impl_int_alignment_for_primitive!(usize);
 pub type BoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
 pub type Qcow2FutureResult<'a, T> = BoxedFuture<'a, Qcow2Result<T>>;
 
-#[macro_export]
-macro_rules! page_aligned_vec {
-    ($type:ty, $size:expr) => {{
-        #[repr(C, align(4096))]
-        #[derive(Clone)]
-        struct PageAlignedBuf([u8; 512]);
-
-        let sz = ($size + 511) & !511;
-        let nr = sz / 512;
-        let buf = Vec::<PageAlignedBuf>::with_capacity(nr);
-        unsafe {
-            let mut a: Vec<$type> = std::mem::transmute(buf);
-            a.set_len(sz / core::mem::size_of::<$type>());
-            a
-        }
-    }};
-}
-
 /// Slice like buffer, which address is aligned with 4096.
 ///
 pub struct Qcow2IoBuf<T> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,10 +2,10 @@ use clap::{Args, Parser, Subcommand};
 use clap_num::maybe_hex;
 use qcow2_rs::dev::{Qcow2DevParams, Qcow2Info};
 use qcow2_rs::error::Qcow2Result;
+use qcow2_rs::helpers::Qcow2IoBuf;
 use qcow2_rs::meta::{
     L1Table, L2Table, Qcow2FeatureType, Qcow2Header, RefBlock, RefTable, Table, TableEntry,
 };
-use qcow2_rs::page_aligned_vec;
 use qcow2_rs::utils::qcow2_setup_dev_tokio;
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::PathBuf;
@@ -620,7 +620,7 @@ fn read_qcow2(args: ReadArgs) -> Qcow2Result<()> {
             eprintln!("unaligned offset {:x} or len {:x}", args.start, len);
         }
 
-        let mut buf = page_aligned_vec!(u8, len);
+        let mut buf = Qcow2IoBuf::<u8>::new(len);
 
         dev.read_at(&mut buf, args.start)
             .await
@@ -648,7 +648,7 @@ fn write_qcow2(args: WriteArgs) -> Qcow2Result<()> {
             eprintln!("unaligned offset {:x} or len {:x}", args.start, len);
         }
 
-        let mut buf = page_aligned_vec!(u8, len);
+        let mut buf = Qcow2IoBuf::<u8>::new(len);
 
         let pattern = (0..=15).cycle().take(buf.len());
         for (elem, pattern_element) in buf.iter_mut().zip(pattern) {

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -420,7 +420,7 @@ impl Qcow2Header {
     pub const MAX_L1_SIZE: u32 = 32_u32 << 20;
     pub const MAX_REFCOUNT_TABLE_SIZE: u32 = 8_u32 << 20;
 
-    pub fn from_buf(header_buf: &Vec<u8>) -> Qcow2Result<Self> {
+    pub fn from_buf(header_buf: &[u8]) -> Qcow2Result<Self> {
         let bincode = bincode::DefaultOptions::new()
             .with_fixint_encoding()
             .with_big_endian();

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -5,9 +5,8 @@
 use crate::dev::Qcow2Info;
 use crate::error::Qcow2Result;
 use crate::helpers::IntAlignment;
+use crate::helpers::Qcow2IoBuf;
 use crate::numerical_enum;
-use crate::page_aligned_vec;
-use crate::zero_buf;
 use bincode::Options;
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
@@ -962,13 +961,13 @@ impl TableEntry for L1Entry {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug)]
 pub struct L1Table {
     header_entries: u32,
     dirty_blocks: RefCell<VecDeque<u32>>,
     bs_bits: u8,
     offset: Option<u64>,
-    data: Box<[L1Entry]>,
+    data: Qcow2IoBuf<L1Entry>,
 }
 
 impl L1Table {
@@ -989,12 +988,12 @@ impl L1Table {
     pub fn clone_and_grow(&self, at_least_index: usize, cluster_size: usize) -> Self {
         let new_size = std::cmp::max(at_least_index + 1, self.data.len());
         let new_size = new_size.align_up(cluster_size).unwrap();
-        let mut new_data = page_aligned_vec!(L1Entry, new_size);
+        let mut new_data = Qcow2IoBuf::<L1Entry>::new(new_size);
         new_data[..self.data.len()].copy_from_slice(&self.data);
 
         Self {
             offset: None,
-            data: new_data.into_boxed_slice(),
+            data: new_data,
             bs_bits: self.bs_bits,
             header_entries: self.data.len() as u32,
             dirty_blocks: RefCell::new(self.dirty_blocks.borrow().clone()),
@@ -1015,13 +1014,14 @@ impl L1Table {
 
 impl_top_table_traits!(L1Table, L1Entry, data);
 
-impl From<Box<[L1Entry]>> for L1Table {
-    fn from(data: Box<[L1Entry]>) -> Self {
+impl From<Qcow2IoBuf<L1Entry>> for L1Table {
+    fn from(data: Qcow2IoBuf<L1Entry>) -> Self {
         Self {
+            bs_bits: 0,
+            header_entries: 0,
             offset: None,
             data,
             dirty_blocks: RefCell::new(VecDeque::new()),
-            ..Default::default()
         }
     }
 }
@@ -1356,11 +1356,11 @@ impl TableEntry for L2Entry {
 // return cluster_offset + (offset % cluster_size)
 //
 // [*] this changes if Extended L2 Entries are enabled, see next section
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct L2Table {
     offset: Option<u64>,
     cluster_bits: u32,
-    data: Box<[L2Entry]>,
+    data: Qcow2IoBuf<L2Entry>,
 }
 
 impl L2Table {
@@ -1428,8 +1428,8 @@ impl L2Table {
     }
 }
 
-impl From<Box<[L2Entry]>> for L2Table {
-    fn from(data: Box<[L2Entry]>) -> Self {
+impl From<Qcow2IoBuf<L2Entry>> for L2Table {
+    fn from(data: Qcow2IoBuf<L2Entry>) -> Self {
         Self {
             offset: None,
             cluster_bits: 0,
@@ -1496,12 +1496,12 @@ impl TableEntry for RefTableEntry {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug)]
 pub struct RefTable {
     dirty_blocks: RefCell<VecDeque<u32>>,
     bs_bits: u8,
     offset: Option<u64>,
-    data: Box<[RefTableEntry]>,
+    data: Qcow2IoBuf<RefTableEntry>,
 }
 
 impl RefTable {
@@ -1525,13 +1525,13 @@ impl RefTable {
             (clusters * cluster_size + bs, None)
         };
 
-        let mut new_data = page_aligned_vec!(RefTableEntry, new_size);
-        zero_buf!(new_data);
+        let mut new_data = Qcow2IoBuf::<RefTableEntry>::new(new_size);
+        new_data.zero_buf();
         new_data[..self.data.len()].copy_from_slice(&self.data);
 
         Self {
             offset: new_off,
-            data: new_data.into_boxed_slice(),
+            data: new_data,
             dirty_blocks: RefCell::new(self.dirty_blocks.borrow().clone()),
             bs_bits: self.bs_bits,
         }
@@ -1550,12 +1550,13 @@ impl RefTable {
     }
 }
 
-impl From<Box<[RefTableEntry]>> for RefTable {
-    fn from(data: Box<[RefTableEntry]>) -> Self {
+impl From<Qcow2IoBuf<RefTableEntry>> for RefTable {
+    fn from(data: Qcow2IoBuf<RefTableEntry>) -> Self {
         Self {
             data,
             dirty_blocks: RefCell::new(VecDeque::new()),
-            ..Default::default()
+            bs_bits: 0,
+            offset: None,
         }
     }
 }
@@ -1586,7 +1587,7 @@ impl TableEntry for RefBlockEntry {
 #[derive(Debug)]
 pub struct RefBlock {
     offset: Option<u64>,
-    raw_data: Box<[u8]>,
+    raw_data: Qcow2IoBuf<RefBlockEntry>,
     refcount_order: u8,
 }
 
@@ -1604,35 +1605,35 @@ impl RefBlock {
 
     #[inline(always)]
     fn __get(&self, index: usize) -> u64 {
+        let raw_data = &self.raw_data.as_u8_slice();
         match self.refcount_order {
             // refcount_bits == 1
-            0 => ((self.raw_data[index / 8] >> (index % 8)) & 0b0000_0001) as u64,
+            0 => ((raw_data[index / 8] >> (index % 8)) & 0b0000_0001) as u64,
 
             // refcount_bits == 2
-            1 => ((self.raw_data[index / 4] >> (index % 4)) & 0b0000_0011) as u64,
+            1 => ((raw_data[index / 4] >> (index % 4)) & 0b0000_0011) as u64,
 
             // refcount_bits == 4
-            2 => ((self.raw_data[index / 2] >> (index % 2)) & 0b0000_1111) as u64,
+            2 => ((raw_data[index / 2] >> (index % 2)) & 0b0000_1111) as u64,
 
             // refcount_bits == 8
-            3 => self.raw_data[index] as u64,
+            3 => raw_data[index] as u64,
 
             // refcount_bits == 16
-            4 => u16::from_be_bytes(self.raw_data[index * 2..index * 2 + 2].try_into().unwrap())
-                as u64,
+            4 => u16::from_be_bytes(raw_data[index * 2..index * 2 + 2].try_into().unwrap()) as u64,
 
             // refcount_bits == 32
-            5 => u32::from_be_bytes(self.raw_data[index * 4..index * 4 + 4].try_into().unwrap())
-                as u64,
+            5 => u32::from_be_bytes(raw_data[index * 4..index * 4 + 4].try_into().unwrap()) as u64,
 
             // refcount_bits == 64
-            6 => u64::from_be_bytes(self.raw_data[index * 8..index * 8 + 8].try_into().unwrap()),
+            6 => u64::from_be_bytes(raw_data[index * 8..index * 8 + 8].try_into().unwrap()),
 
             _ => unreachable!(),
         }
     }
 
     fn __set(&mut self, index: usize, value: u64) -> Qcow2Result<()> {
+        let raw_data = &mut self.raw_data.as_u8_slice_mut();
         match self.refcount_order {
             // refcount_bits == 1
             0 => {
@@ -1643,8 +1644,7 @@ impl RefBlock {
                     )
                     .into());
                 }
-                self.raw_data[index / 8] = (self.raw_data[index / 8]
-                    & !(0b0000_0001 << (index % 8)))
+                raw_data[index / 8] = (raw_data[index / 8] & !(0b0000_0001 << (index % 8)))
                     | ((value as u8) << (index % 8));
             }
 
@@ -1657,8 +1657,7 @@ impl RefBlock {
                     )
                     .into());
                 }
-                self.raw_data[index / 4] = (self.raw_data[index / 4]
-                    & !(0b0000_0011 << (index % 4)))
+                raw_data[index / 4] = (raw_data[index / 4] & !(0b0000_0011 << (index % 4)))
                     | ((value as u8) << (index % 4));
             }
 
@@ -1671,8 +1670,7 @@ impl RefBlock {
                     )
                     .into());
                 }
-                self.raw_data[index / 2] = (self.raw_data[index / 2]
-                    & !(0b0000_1111 << (index % 2)))
+                raw_data[index / 2] = (raw_data[index / 2] & !(0b0000_1111 << (index % 2)))
                     | ((value as u8) << (index % 2));
             }
 
@@ -1685,7 +1683,7 @@ impl RefBlock {
                     )
                     .into());
                 }
-                self.raw_data[index] = value as u8;
+                raw_data[index] = value as u8;
             }
 
             // refcount_bits == 16
@@ -1697,8 +1695,8 @@ impl RefBlock {
                     )
                     .into());
                 }
-                self.raw_data[index * 2] = (value >> 8) as u8;
-                self.raw_data[index * 2 + 1] = value as u8;
+                raw_data[index * 2] = (value >> 8) as u8;
+                raw_data[index * 2 + 1] = value as u8;
             }
 
             // refcount_bits == 32
@@ -1710,15 +1708,15 @@ impl RefBlock {
                     )
                     .into());
                 }
-                self.raw_data[index * 4] = (value >> 24) as u8;
-                self.raw_data[index * 4 + 1] = (value >> 16) as u8;
-                self.raw_data[index * 4 + 2] = (value >> 8) as u8;
-                self.raw_data[index * 4 + 3] = value as u8;
+                raw_data[index * 4] = (value >> 24) as u8;
+                raw_data[index * 4 + 1] = (value >> 16) as u8;
+                raw_data[index * 4 + 2] = (value >> 8) as u8;
+                raw_data[index * 4 + 3] = value as u8;
             }
 
             // refcount_bits == 64
             6 => {
-                let array: &mut [u8; 8] = (&mut self.raw_data[index * 8..index * 8 + 8])
+                let array: &mut [u8; 8] = (&mut raw_data[index * 8..index * 8 + 8])
                     .try_into()
                     .unwrap();
                 *array = value.to_be_bytes();
@@ -1811,7 +1809,7 @@ impl Table for RefBlock {
     impl_table_gen_funcs!(raw_data);
 
     fn entries(&self) -> usize {
-        self.raw_data.len() * 8 / (1 << self.refcount_order)
+        self.byte_size() * 8 / (1 << self.refcount_order)
     }
 
     fn get(&self, index: usize) -> Self::Entry {
@@ -1826,21 +1824,18 @@ impl Table for RefBlock {
         self.__set(index, value.into_plain())
     }
 
+    /// RefBlock is special, since RefBlockEntry is defined as u64
     fn byte_size(&self) -> usize {
-        self.raw_data.len()
+        self.raw_data.len() * 8
     }
 }
 
-impl From<Box<[RefBlockEntry]>> for RefBlock {
-    fn from(data: Box<[RefBlockEntry]>) -> Self {
-        let len = data.len() * size_of::<RefBlockEntry>();
-        let ptr = Box::into_raw(data);
-        let _data: Box<[u8]> =
-            unsafe { Box::from_raw(std::slice::from_raw_parts_mut(ptr as *mut u8, len)) };
+impl From<Qcow2IoBuf<RefBlockEntry>> for RefBlock {
+    fn from(data: Qcow2IoBuf<RefBlockEntry>) -> Self {
         Self {
             offset: None,
             refcount_order: 0,
-            raw_data: _data,
+            raw_data: data,
         }
     }
 }
@@ -1859,7 +1854,7 @@ where
     }
 }
 
-pub trait Table: From<Box<[Self::Entry]>> {
+pub trait Table: From<Qcow2IoBuf<Self::Entry>> {
     type Entry: TableEntry;
 
     fn entries(&self) -> usize;
@@ -1889,11 +1884,11 @@ pub trait Table: From<Box<[Self::Entry]>> {
     }
 
     fn new_empty(offset: Option<u64>, size: usize) -> Self {
-        let mut table = page_aligned_vec!(Self::Entry, size);
+        let table = Qcow2IoBuf::<Self::Entry>::new(size);
         unsafe {
             std::ptr::write_bytes(table.as_mut_ptr(), 0, table.len());
         }
-        let mut table: Self = table.into_boxed_slice().into();
+        let mut table: Self = table.into();
         table.set_offset(offset);
 
         table

--- a/src/sync_io.rs
+++ b/src/sync_io.rs
@@ -120,9 +120,9 @@ impl Qcow2IoOps for Qcow2IoSync {
     }
     #[cfg(not(target_os = "linux"))]
     async fn fallocate(&self, offset: u64, len: usize, _flags: u32) -> Qcow2Result<()> {
-        let mut data = crate::page_aligned_vec!(u8, len);
-        crate::zero_buf!(data);
+        let mut data = crate::helpers::Qcow2IoBuf::<u8>::new(len);
 
+        data.zero_buf();
         self.write_at(offset, &data).await
     }
 

--- a/src/tokio_io.rs
+++ b/src/tokio_io.rs
@@ -95,9 +95,9 @@ impl Qcow2IoOps for Qcow2IoTokio {
     }
     #[cfg(not(target_os = "linux"))]
     async fn fallocate(&self, offset: u64, len: usize, _flags: u32) -> Qcow2Result<()> {
-        let mut data = crate::page_aligned_vec!(u8, len);
-        crate::zero_buf!(data);
+        let mut data = crate::helpers::Qcow2IoBuf::<u8>::new(len);
 
+        data.zero_buf();
         self.write_at(offset, &data).await
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,8 @@
 use crate::dev::{Qcow2Dev, Qcow2DevParams};
 use crate::error::Qcow2Result;
+use crate::helpers::Qcow2IoBuf;
 use crate::meta::Qcow2Header;
 use crate::ops::*;
-use crate::page_aligned_vec;
 #[cfg(not(target_os = "windows"))]
 use crate::sync_io::Qcow2IoSync;
 #[cfg(target_os = "linux")]
@@ -22,7 +22,7 @@ pub fn qcow2_alloc_dev_sync<T: Qcow2IoOps>(
     io: T,
     params: &Qcow2DevParams,
 ) -> Qcow2Result<(Qcow2Dev<T>, Option<PathBuf>)> {
-    let mut buf = page_aligned_vec!(u8, 4096);
+    let mut buf = Qcow2IoBuf::<u8>::new(4096);
     {
         use std::io::Read;
         let mut file = std::fs::File::open(path).unwrap();
@@ -45,7 +45,7 @@ pub async fn qcow2_alloc_dev<T: Qcow2IoOps>(
     io: T,
     params: &Qcow2DevParams,
 ) -> Qcow2Result<(Qcow2Dev<T>, Option<PathBuf>)> {
-    let mut buf = page_aligned_vec!(u8, 4096);
+    let mut buf = Qcow2IoBuf::<u8>::new(4096);
     let _ = io.read_to(0, &mut buf).await;
     let header = Qcow2Header::from_buf(&buf)?;
     let back_path = match header.backing_filename() {

--- a/tests/sync_io.rs
+++ b/tests/sync_io.rs
@@ -5,8 +5,8 @@ extern crate utilities;
 mod sync_io_integretion {
     use crypto_hash::{hex_digest, Algorithm};
     use qcow2_rs::dev::*;
+    use qcow2_rs::qcow2_default_params;
     use qcow2_rs::utils::*;
-    use qcow2_rs::{page_aligned_vec, qcow2_default_params};
     use std::path::PathBuf;
     use tokio::runtime::Runtime;
     use utilities::*;
@@ -18,7 +18,7 @@ mod sync_io_integretion {
 
         dev.qcow2_prep_io().await.unwrap();
 
-        let mut buf = page_aligned_vec!(u8, size as usize);
+        let mut buf = qcow2_rs::helpers::Qcow2IoBuf::<u8>::new(size as usize);
         dev.read_at(&mut buf, 0).await.unwrap();
 
         hex_digest(Algorithm::MD5, &buf)


### PR DESCRIPTION

- convert page_aligned_vec!() into Qcow2Iobuf, which is guaranteed that same alloc layout is used in both allocation
and deallocation,

- this way fixes "(exit code: 0xc0000374, STATUS_HEAP_CORRUPTION)" when running `cargo test`

- add CI for covering windows build & test