### PR TITLE
qcow2-rs: fix(meta): Prevent panic on malformed qcow2 header

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,4 @@ tokio-uring = { version = "0.5"}
 tempfile = "3.6.0"
 crypto-hash = "0.3"
 rand = "0.8"
+hex = "0.4.3"

--- a/src/meta.rs
+++ b/src/meta.rs
@@ -441,7 +441,12 @@ impl Qcow2Header {
             header.refcount_order = 4;
         }
 
-        let cluster_size = 1u64 << header.cluster_bits;
+        let cluster_bits = header.cluster_bits;
+        if !(9..=30).contains(&cluster_bits) {
+            return Err(format!("qcow2 cluster_bits {} is invalid", cluster_bits).into());
+        }
+
+        let cluster_size = 1u64 << cluster_bits;
         if cluster_size > Self::MAX_CLUSTER_SIZE as u64 {
             return Err(format!("qcow2 cluster size {} is too big", cluster_size).into());
         }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -13,6 +13,14 @@ mod integretion {
     use std::path::PathBuf;
     use std::time::Instant;
     use tokio::runtime::Runtime;
+    use hex;
+
+    #[test]
+    fn test_qcow2_parsing() {
+        let data = hex::decode("514649fb252525fa494651252525e7e70000000000000069252525252525252525252525252525252525252525252525252525252525252525252525252525252525252525252525252525252525252525252525252525252525252525252525252525252525252525").unwrap();
+        let qcow2_hdr = qcow2_rs::meta::Qcow2Header::from_buf(&data[..]);
+        assert!(qcow2_hdr.is_err());
+    }
 
     #[test]
     fn test_qcow2_dev_read_null() {


### PR DESCRIPTION
A malformed qcow2 header with an invalid cluster_bits value could cause a panic due to a left-shift overflow when calculating the cluster size. This could be triggered by a crafted qcow2 image, leading to a denial of service.

This commit fixes the issue by validating the cluster_bits field before it is used. The value is now checked to be within a valid range (9 to 30, inclusive) to prevent the overflow. If the value is out of range, the header parsing function now returns an error instead of panicking.

A test case with a known malformed header has been added to ensure this vulnerability does not regress.