### PR TITLE
Replace unwrap panics with proper error propagation

### DIFF
--- a/src/dev.rs
+++ b/src/dev.rs
@@ -2883,18 +2883,20 @@ impl<T: Qcow2IoOps> Qcow2Dev<T> {
     async fn check_cluster(&self, virt_off: u64, cluster: Option<u64>) -> Qcow2Result<()> {
         match cluster {
             None => Ok(()),
-            Some(host_cluster) => {
-                match self.cluster_is_allocated(host_cluster).await? {
-                    false => {
-                        eprintln!(
-                            "virt_offset {:x} pointed to non-allocated cluster {:x}",
-                            virt_off, host_cluster
-                        );
-                    }
-                    true => {}
+            Some(host_cluster) => match self.cluster_is_allocated(host_cluster).await? {
+                true => Ok(()),
+                false => {
+                    eprintln!(
+                        "virt_offset {:x} pointed to non-allocated cluster {:x}",
+                        virt_off, host_cluster
+                    );
+                    Err(format!(
+                        "check: virt_offset {:x} pointed to non-allocated cluster {:x}",
+                        virt_off, host_cluster
+                    )
+                    .into())
                 }
-                Ok(())
-            }
+            },
         }
     }
 

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -2952,7 +2952,9 @@ mod tests {
         rt.block_on(async move {
             let size = 64_u64 << 20;
             let img_file = make_temp_qcow2_img(size, 16, 4);
-            let io = Qcow2IoTokio::new(&img_file.path().to_path_buf(), true, false).await;
+            let io = Qcow2IoTokio::new(&img_file.path().to_path_buf(), true, false)
+                .await
+                .unwrap();
             let mut buf = Qcow2IoBuf::<u8>::new(4096);
             let _ = io.read_to(0, &mut buf).await;
             let header = Qcow2Header::from_buf(&buf).unwrap();

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -2753,18 +2753,20 @@ impl<T: Qcow2IoOps> Qcow2Dev<T> {
     async fn check_cluster(&self, virt_off: u64, cluster: Option<u64>) -> Qcow2Result<()> {
         match cluster {
             None => Ok(()),
-            Some(host_cluster) => {
-                match self.cluster_is_allocated(host_cluster).await? {
-                    false => {
-                        eprintln!(
-                            "virt_offset {:x} pointed to non-allocated cluster {:x}",
-                            virt_off, host_cluster
-                        );
-                    }
-                    true => {}
+            Some(host_cluster) => match self.cluster_is_allocated(host_cluster).await? {
+                true => Ok(()),
+                false => {
+                    eprintln!(
+                        "virt_offset {:x} pointed to non-allocated cluster {:x}",
+                        virt_off, host_cluster
+                    );
+                    Err(format!(
+                        "check: virt_offset {:x} pointed to non-allocated cluster {:x}",
+                        virt_off, host_cluster
+                    )
+                    .into())
                 }
-                Ok(())
-            }
+            },
         }
     }
 

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -3082,7 +3082,9 @@ mod tests {
         rt.block_on(async move {
             let size = 64_u64 << 20;
             let img_file = make_temp_qcow2_img(size, 16, 4);
-            let io = Qcow2IoTokio::new(&img_file.path().to_path_buf(), true, false).await;
+            let io = Qcow2IoTokio::new(&img_file.path().to_path_buf(), true, false)
+                .await
+                .unwrap();
             let mut buf = Qcow2IoBuf::<u8>::new(4096);
             let _ = io.read_to(0, &mut buf).await;
             let header = Qcow2Header::from_buf(&buf).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -543,12 +543,10 @@ fn check_qcow2(args: CheckArgs) -> Qcow2Result<()> {
 
     rt.block_on(async move {
         let p = qcow2_rs::qcow2_default_params!(false, false);
-        let dev = qcow2_setup_dev_tokio(&args.file, &p).await.unwrap();
+        let dev = qcow2_setup_dev_tokio(&args.file, &p).await?;
 
-        dev.check().await.expect("check failed");
-    });
-
-    Ok(())
+        dev.check().await
+    })
 }
 
 async fn copy_from_qcow2<T: Qcow2IoOps>(
@@ -725,12 +723,17 @@ fn main() {
         .format_timestamp(None)
         .init();
 
-    match cli.command {
-        Commands::Dump(arg) => dump_qcow2(arg).unwrap(),
-        Commands::Format(arg) => format_qcow2(arg).unwrap(),
-        Commands::Map(arg) => map_qcow2(arg).unwrap(),
-        Commands::Info(arg) => info_qcow2(arg).unwrap(),
-        Commands::Check(arg) => check_qcow2(arg).unwrap(),
-        Commands::Convert(arg) => convert_qcow2(arg).unwrap(),
+    let result = match cli.command {
+        Commands::Dump(arg) => dump_qcow2(arg),
+        Commands::Format(arg) => format_qcow2(arg),
+        Commands::Map(arg) => map_qcow2(arg),
+        Commands::Info(arg) => info_qcow2(arg),
+        Commands::Check(arg) => check_qcow2(arg),
+        Commands::Convert(arg) => convert_qcow2(arg),
     };
+
+    if let Err(e) = result {
+        eprintln!("error: {}", e);
+        std::process::exit(1);
+    }
 }

--- a/src/sync_io.rs
+++ b/src/sync_io.rs
@@ -16,7 +16,7 @@ pub struct Qcow2IoSync {
 }
 
 impl Qcow2IoSync {
-    pub fn new(path: &Path, ro: bool, dio: bool) -> Qcow2IoSync {
+    pub fn new(path: &Path, ro: bool, dio: bool) -> Qcow2Result<Qcow2IoSync> {
         #[cfg(target_os = "macos")]
         fn set_dio(_file: &File) {}
 
@@ -27,17 +27,17 @@ impl Qcow2IoSync {
             }
         }
 
-        let file = OpenOptions::new().read(true).write(!ro).open(path).unwrap();
+        let file = OpenOptions::new().read(true).write(!ro).open(path)?;
 
         if dio {
             set_dio(&file);
         }
 
         let fd = file.as_raw_fd();
-        Qcow2IoSync {
+        Ok(Qcow2IoSync {
             _file: RefCell::new(file),
             fd,
-        }
+        })
     }
 
     #[inline(always)]

--- a/src/tokio_io.rs
+++ b/src/tokio_io.rs
@@ -26,37 +26,35 @@ pub struct Qcow2IoTokio {
 
 impl Qcow2IoTokio {
     #[cfg(target_os = "linux")]
-    pub async fn new(path: &Path, ro: bool, dio: bool) -> Qcow2IoTokio {
+    pub async fn new(path: &Path, ro: bool, dio: bool) -> Qcow2Result<Qcow2IoTokio> {
         let file = OpenOptions::new()
             .read(true)
             .write(!ro)
             .open(path.to_path_buf())
-            .await
-            .unwrap();
+            .await?;
 
         assert!(!dio);
 
         let fd = file.as_raw_fd();
-        Qcow2IoTokio {
+        Ok(Qcow2IoTokio {
             file: tokio::sync::Mutex::new(file),
             fd,
-        }
+        })
     }
 
     #[cfg(not(target_os = "linux"))]
-    pub async fn new(path: &Path, ro: bool, dio: bool) -> Qcow2IoTokio {
+    pub async fn new(path: &Path, ro: bool, dio: bool) -> Qcow2Result<Qcow2IoTokio> {
         let file = OpenOptions::new()
             .read(true)
             .write(!ro)
             .open(path.to_path_buf())
-            .await
-            .unwrap();
+            .await?;
 
         assert!(!dio);
 
-        Qcow2IoTokio {
+        Ok(Qcow2IoTokio {
             file: tokio::sync::Mutex::new(file),
-        }
+        })
     }
 
     async fn write_at(&self, offset: u64, buf: &[u8]) -> Qcow2Result<()> {

--- a/src/tokio_io.rs
+++ b/src/tokio_io.rs
@@ -26,37 +26,35 @@ pub struct Qcow2IoTokio {
 
 impl Qcow2IoTokio {
     #[cfg(any(target_os = "linux", target_os = "macos"))]
-    pub async fn new(path: &Path, ro: bool, dio: bool) -> Qcow2IoTokio {
+    pub async fn new(path: &Path, ro: bool, dio: bool) -> Qcow2Result<Qcow2IoTokio> {
         let file = OpenOptions::new()
             .read(true)
             .write(!ro)
             .open(path.to_path_buf())
-            .await
-            .unwrap();
+            .await?;
 
         assert!(!dio);
 
         let fd = file.as_raw_fd();
-        Qcow2IoTokio {
+        Ok(Qcow2IoTokio {
             file: tokio::sync::Mutex::new(file),
             fd,
-        }
+        })
     }
 
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
-    pub async fn new(path: &Path, ro: bool, dio: bool) -> Qcow2IoTokio {
+    pub async fn new(path: &Path, ro: bool, dio: bool) -> Qcow2Result<Qcow2IoTokio> {
         let file = OpenOptions::new()
             .read(true)
             .write(!ro)
             .open(path.to_path_buf())
-            .await
-            .unwrap();
+            .await?;
 
         assert!(!dio);
 
-        Qcow2IoTokio {
+        Ok(Qcow2IoTokio {
             file: tokio::sync::Mutex::new(file),
-        }
+        })
     }
 
     async fn write_at(&self, offset: u64, buf: &[u8]) -> Qcow2Result<()> {

--- a/src/uring.rs
+++ b/src/uring.rs
@@ -81,20 +81,19 @@ pub struct Qcow2IoUring {
 }
 
 impl Qcow2IoUring {
-    pub async fn new(path: &Path, ro: bool, dio: bool) -> Qcow2IoUring {
+    pub async fn new(path: &Path, ro: bool, dio: bool) -> Qcow2Result<Qcow2IoUring> {
         let file = OpenOptions::new()
             .read(true)
             .write(!ro)
             .open(path.to_path_buf())
-            .await
-            .unwrap();
+            .await?;
 
         if dio {
             unsafe {
                 libc::fcntl(file.as_raw_fd(), libc::F_SETFL, libc::O_DIRECT);
             }
         }
-        Qcow2IoUring { file }
+        Ok(Qcow2IoUring { file })
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -94,7 +94,7 @@ macro_rules! qcow2_setup_dev_fn {
             path: &Path,
             params: &Qcow2DevParams,
         ) -> Qcow2Result<Qcow2Dev<$type>> {
-            let io = <$type>::new(path, params.is_read_only(), params.is_direct_io()).await;
+            let io = <$type>::new(path, params.is_read_only(), params.is_direct_io()).await?;
             let (mut dev, backing) = qcow2_alloc_dev(&path, io, params).await?;
             match backing {
                 Some(back_path) => {
@@ -124,7 +124,7 @@ qcow2_setup_dev_fn!(crate::tokio_io::Qcow2IoTokio, qcow2_setup_dev_tokio);
 macro_rules! qcow2_setup_dev_fn_sync {
     ($type:ty, $fn_name: ident) => {
         pub fn $fn_name(path: &Path, params: &Qcow2DevParams) -> Qcow2Result<Qcow2Dev<$type>> {
-            let io = <$type>::new(path, params.is_read_only(), params.is_direct_io());
+            let io = <$type>::new(path, params.is_read_only(), params.is_direct_io())?;
             let (mut dev, backing) = qcow2_alloc_dev_sync(&path, io, params)?;
             match backing {
                 Some(back_path) => {

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -4,6 +4,7 @@ mod common;
 mod integretion {
     use crate::common::*;
     use crypto_hash::{hex_digest, Algorithm};
+    use hex;
     use qcow2_rs::dev::*;
     use qcow2_rs::helpers::Qcow2IoBuf;
     use qcow2_rs::qcow2_default_params;
@@ -13,7 +14,6 @@ mod integretion {
     use std::path::PathBuf;
     use std::time::Instant;
     use tokio::runtime::Runtime;
-    use hex;
 
     #[test]
     fn test_qcow2_parsing() {


### PR DESCRIPTION
I'm using qcow2-rs as a library via rublk to expose qcow2 images as ublk block devices. When rublk hits a corrupt or malformed image, the unwrap() in the IO backend's new() panics and kills the daemon. Since the kernel-side ublk device is already registered at that point, the orphaned device causes unkillable D-state processes — only a reboot fixes it.

This patch replaces unwrap() with proper error propagation across all IO backends and the setup macros, so callers get a clean error instead of a process crash.

Also fixes `rqcow2 check` — it was printing "non-allocated cluster" warnings but still returning exit 0, which made it useless for scripted pre-validation. Now it returns exit 1 on integrity errors.

Changes:
- `Qcow2IoSync::new()`, `Qcow2IoTokio::new()`, `Qcow2IoUring::new()` return `Qcow2Result` instead of panicking on file open
- `qcow2_setup_dev_fn_sync!` and `qcow2_setup_dev_fn!` macros propagate the error with `?`
- `check_cluster()` returns `Err` when a cluster is non-allocated (was `Ok(())`)
- `main()` prints the error and exits 1 instead of panicking

Tested against a mix of valid and corrupt qcow2 images.