### PR TITLE
qcow2-rs: warn instead of panic when dropping dirty cache entries

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -219,7 +219,28 @@ impl<V> AsyncLruCacheEntryInner<V> {
 }
 
 impl<V> Drop for AsyncLruCacheEntryInner<V> {
+    /// A dirty cache entry at drop time means the caller dropped the
+    /// `Qcow2Dev` without first calling `flush_meta()` — the in-memory
+    /// modifications never reached disk. The previous behavior was to
+    /// `assert!` here, which turns the silent data loss into a panic
+    /// during drop. Panicking in `Drop` is hostile in async contexts:
+    /// during runtime teardown (or while a different panic is already
+    /// unwinding) it escalates to process abort, and even in the
+    /// graceful case it makes the missed-flush bug harder to investigate
+    /// because the panic message has no async backtrace.
+    ///
+    /// Logging at WARN level surfaces the same diagnostic without
+    /// stealing control of the unwind. The data loss is already done
+    /// by the time we get here; the user's bug is "didn't flush", and
+    /// they need to find it from the warning + their own backtrace,
+    /// not from a Drop-time panic.
     fn drop(&mut self) {
-        assert!(!self.is_dirty());
+        if self.is_dirty() {
+            log::warn!(
+                "AsyncLruCacheEntryInner<{}> dropped with dirty=true; \
+                 modifications were not flushed to disk (missing flush_meta?)",
+                std::any::type_name::<V>(),
+            );
+        }
     }
 }

--- a/tests/drop.rs
+++ b/tests/drop.rs
@@ -1,0 +1,108 @@
+//! `AsyncLruCacheEntryInner::drop` behavior on dirty cache entries.
+//!
+//! Verifies that dropping a `Qcow2Dev` whose internal LRU caches still
+//! have dirty entries does not panic. Previously this asserted, which
+//! turned a silent missed-flush bug into a hostile drop-time panic
+//! (and during async runtime teardown, a process abort).
+//!
+//! The new behavior is to log at WARN level and continue. The data is
+//! still lost — we cannot recover from `Drop` — but the program does
+//! not abort, callers above us in the stack can finish cleanly, and
+//! the operator finds the missing-flush bug from the WARN message
+//! rather than from a panic with no async backtrace.
+//!
+//! These tests run on every platform; no cfg gates needed.
+
+#[cfg(test)]
+mod drop_behavior {
+    use qcow2_rs::dev::*;
+    use qcow2_rs::helpers::Qcow2IoBuf;
+    use qcow2_rs::qcow2_default_params;
+    use qcow2_rs::utils::{make_temp_qcow2_img, qcow2_setup_dev_tokio};
+    use tokio::runtime::Runtime;
+
+    const CLUSTER_BITS: usize = 16;
+    const CLUSTER_SIZE: usize = 1 << CLUSTER_BITS;
+
+    fn nonzero_buf(len: usize, pattern: u8) -> Qcow2IoBuf<u8> {
+        let mut buf = Qcow2IoBuf::<u8>::new(len);
+        for b in &mut buf[..] {
+            *b = pattern;
+        }
+        buf
+    }
+
+    /// T1 — happy path: write, flush_meta, drop. The flush clears all
+    /// dirty bits before drop, so the drop path takes the no-warn
+    /// branch. This is the existing canonical usage pattern and the
+    /// regression anchor that the new Drop impl doesn't break it.
+    #[test]
+    fn flush_meta_then_drop_is_clean() {
+        let rt = Runtime::new().unwrap();
+        rt.block_on(async {
+            let virt_size = 1 << 20;
+            let img = make_temp_qcow2_img(virt_size, CLUSTER_BITS, 4);
+            let path = img.path().to_path_buf();
+            let params = qcow2_default_params!(false, false);
+            let dev = qcow2_setup_dev_tokio(&path, &params).await.unwrap();
+
+            let buf = nonzero_buf(CLUSTER_SIZE, 0x55);
+            dev.write_at(&buf, 0).await.unwrap();
+            dev.flush_meta().await.unwrap();
+
+            // dev drops here at end of block. Cache entries are clean
+            // (flush_meta cleared dirty), so the drop is a no-op.
+        });
+    }
+
+    /// T2 — dirty-drop path: write, SKIP flush_meta, drop. Previously
+    /// this hit `assert!(!self.is_dirty())` inside the LRU cache entry's
+    /// Drop and the test would panic. With the new behavior the drop
+    /// emits a `log::warn!` and continues; the test framework's normal
+    /// panic-catching reports nothing wrong, so the test passes.
+    ///
+    /// The data on disk is still lost (drop can't recover writes), but
+    /// the program doesn't abort. That's the contract we're testing:
+    /// "missing-flush is a warning, not a panic."
+    #[test]
+    fn dirty_drop_does_not_panic() {
+        let rt = Runtime::new().unwrap();
+        rt.block_on(async {
+            let virt_size = 1 << 20;
+            let img = make_temp_qcow2_img(virt_size, CLUSTER_BITS, 4);
+            let path = img.path().to_path_buf();
+            let params = qcow2_default_params!(false, false);
+            let dev = qcow2_setup_dev_tokio(&path, &params).await.unwrap();
+
+            let buf = nonzero_buf(CLUSTER_SIZE, 0x99);
+            dev.write_at(&buf, 0).await.unwrap();
+            // Deliberately skip flush_meta — cache entries stay dirty.
+
+            // dev drops here at end of block. The Drop impl logs a warn
+            // about the dirty entries; the test must complete without
+            // panicking.
+        });
+    }
+
+    /// T3 — repeated dirty drops in the same process work. Verifies the
+    /// new Drop behavior is stateless (no global flag that could trip
+    /// on the second invocation) and that running this test alongside
+    /// other tests in the same binary is safe.
+    #[test]
+    fn repeated_dirty_drops_are_independent() {
+        let rt = Runtime::new().unwrap();
+        rt.block_on(async {
+            for round in 0..3 {
+                let virt_size = 1 << 20;
+                let img = make_temp_qcow2_img(virt_size, CLUSTER_BITS, 4);
+                let path = img.path().to_path_buf();
+                let params = qcow2_default_params!(false, false);
+                let dev = qcow2_setup_dev_tokio(&path, &params).await.unwrap();
+
+                let buf = nonzero_buf(CLUSTER_SIZE, 0x10 + round as u8);
+                dev.write_at(&buf, 0).await.unwrap();
+                // Skip flush_meta on every iteration.
+            }
+        });
+    }
+}


### PR DESCRIPTION
# qcow2-rs: warn instead of panic when dropping dirty cache entries

## Summary

Replace `assert!(!self.is_dirty())` inside `AsyncLruCacheEntryInner::drop` with a `log::warn!` that reports the entry type. The data loss when a caller forgets `flush_meta()` is unchanged (it was always there once Drop ran); the new behavior just doesn't escalate to a panic that can abort the process during async runtime teardown.

## Motivation

The current Drop has a defensive assert intended to catch missed flushes. In practice:

- Panicking in `Drop` while another panic is already unwinding aborts the process.
- During tokio runtime shutdown, dropping a `Qcow2Dev` can race with the runtime's own teardown. An assert here turns "you forgot to flush" into "the whole program crashed."
- The panic has no async backtrace, so the operator's debugging cost is high.
- Downstream wrappers have to add elaborate workarounds (actor threads, manual pre-Drop flushes) just to avoid tripping this assert.

The data is already lost by the time Drop runs — the assert doesn't recover it. Logging a clear warning gives the operator the same diagnostic without the process-abort downside.

## Behavior

- Cache entry's `dirty` bit is **false** at drop time (normal, post-`flush_meta()` path): no log output, no change.
- Cache entry's `dirty` bit is **true** at drop time: emits `WARN AsyncLruCacheEntryInner<TYPE> dropped with dirty=true; modifications were not flushed to disk (missing flush_meta?)`. The `<TYPE>` is the generic V (typically `L2Table` or `RefBlock`), via `std::any::type_name`.

## Tests

Three tests in `tests/drop.rs`:

| Test | Asserts |
|---|---|
| `flush_meta_then_drop_is_clean` | Happy path. Write, flush, drop. No warn (cache is clean). Regression anchor that the new Drop doesn't break canonical usage. |
| `dirty_drop_does_not_panic` | Write, **skip** flush, drop. Previously panicked from the assert; now emits a warn and completes. The test's success is the proof — the framework would catch a panic and fail. |
| `repeated_dirty_drops_are_independent` | Three back-to-back dirty drops in the same process. Verifies the new behavior is stateless and safe to run alongside other tests in the same binary. |

## Reproduce

```
cargo test --release --test drop
```

## Why this matters for embedders

If you wrap qcow2-rs behind a long-lived service (an iSCSI target backing a VM, a userspace block device, etc.), the previous assert forces you to either:
- Run the device on a dedicated actor thread and orchestrate a pre-drop flush, or
- Trust that every error path remembers to call `flush_meta` before drop.

Neither is ergonomic. With this change, `Qcow2Dev` can be dropped from any context (panic recovery, runtime shutdown, error early-return) without bringing down the process. Missed flushes still produce log evidence so the underlying bug is discoverable.

## Out of scope (intentional)

- No change to the `Qcow2Dev` flush contract. Callers still must call `flush_meta()` to persist writes; the difference is only what happens when they forget.
- No change to anywhere else `assert!` / `panic!` is used in qcow2-rs.
- No new API surface.

## Disclosure

Co-developed with Claude Code (Claude Opus 4.7, 1M context). I reviewed every line and can answer questions about the design or implementation.
